### PR TITLE
Feature request - Full message format without i18n

### DIFF
--- a/activemodel/lib/active_model/error.rb
+++ b/activemodel/lib/active_model/error.rb
@@ -8,17 +8,19 @@ module ActiveModel
   # Represents one single error
   class Error
     CALLBACKS_OPTIONS = [:if, :unless, :on, :allow_nil, :allow_blank, :strict]
-    MESSAGE_OPTIONS = [:message]
+    MESSAGE_OPTIONS = [:message, :full_message, :full_message_format]
 
     class_attribute :i18n_customize_full_message, default: false
 
-    def self.full_message(attribute, message, base) # :nodoc:
+    def self.full_message(attribute, message, base, full_message_format = nil) # :nodoc:
       return message if attribute == :base
 
       base_class = base.class
       attribute = attribute.to_s
 
-      if i18n_customize_full_message && base_class.respond_to?(:i18n_scope)
+      defaults = if full_message_format
+        [:"errors.hardcoded_format", full_message_format]
+      elsif i18n_customize_full_message && base_class.respond_to?(:i18n_scope)
         attribute = attribute.remove(/\[\d+\]/)
         parts = attribute.split(".")
         attribute_name = parts.pop
@@ -26,24 +28,22 @@ module ActiveModel
         attributes_scope = "#{base_class.i18n_scope}.errors.models"
 
         if namespace
-          defaults = base_class.lookup_ancestors.map do |klass|
+          base_class.lookup_ancestors.flat_map do |klass|
             [
               :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.attributes.#{attribute_name}.format",
               :"#{attributes_scope}.#{klass.model_name.i18n_key}/#{namespace}.format",
             ]
           end
         else
-          defaults = base_class.lookup_ancestors.map do |klass|
+          base_class.lookup_ancestors.flat_map do |klass|
             [
               :"#{attributes_scope}.#{klass.model_name.i18n_key}.attributes.#{attribute_name}.format",
               :"#{attributes_scope}.#{klass.model_name.i18n_key}.format",
             ]
           end
         end
-
-        defaults.flatten!
       else
-        defaults = []
+        []
       end
 
       defaults << :"errors.format"
@@ -106,6 +106,11 @@ module ActiveModel
       @raw_type = type
       @type = type || :invalid
       @options = options
+
+      if full_message = @options.delete(:full_message)
+        @options[:message] = full_message
+        @options[:full_message_format] = "%{message}"
+      end
     end
 
     def initialize_dup(other) # :nodoc:
@@ -156,7 +161,7 @@ module ActiveModel
     #   error.full_message
     #   # => "Name is too short (minimum is 5 characters)"
     def full_message
-      self.class.full_message(attribute, message, @base)
+      self.class.full_message(attribute, message, @base, @options[:full_message_format])
     end
 
     # See if error matches provided +attribute+, +type+ and +options+.

--- a/activemodel/lib/active_model/errors.rb
+++ b/activemodel/lib/active_model/errors.rb
@@ -518,8 +518,8 @@ module ActiveModel
     # Returns a full message for a given attribute.
     #
     #   person.errors.full_message(:name, 'is invalid') # => "Name is invalid"
-    def full_message(attribute, message)
-      Error.full_message(attribute, message, @base)
+    def full_message(attribute, message, full_message_format: nil)
+      Error.full_message(attribute, message, @base, full_message_format)
     end
 
     # Translates an error message in its default scope

--- a/activemodel/test/cases/error_test.rb
+++ b/activemodel/test/cases/error_test.rb
@@ -190,6 +190,31 @@ class ErrorTest < ActiveModel::TestCase
     }
   end
 
+  test "full_message returns the given message when passed full_message option" do
+    error = ActiveModel::Error.new(Person.new, :name, full_message: "press the button")
+    assert_equal "press the button", error.full_message
+    # Use a locale without errors.format
+    I18n.with_locale(:unknown) { assert_equal "press the button", error.full_message }
+  end
+
+  test "full_message returns the given message formatted when passed full_message_format option" do
+    error = ActiveModel::Error.new(Person.new, :name, message: "press the button", full_message_format: "%{message}")
+    assert_equal "press the button", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, :blank, full_message_format: "%{message}")
+    assert_equal "can't be blank", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, :blank, full_message_format: "%{attribute} %{message}")
+    assert_equal "name can't be blank", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, :blank, full_message_format: "hardcoded message")
+    assert_equal "hardcoded message", error.full_message
+
+    error = ActiveModel::Error.new(Person.new, :name, message: "press the button", full_message_format: "%{message}")
+    # Use a locale without errors.format
+    I18n.with_locale(:unknown) { assert_equal "press the button", error.full_message }
+  end
+
   test "equality by base attribute, type and options" do
     person = Person.new
 
@@ -232,7 +257,9 @@ class ErrorTest < ActiveModel::TestCase
       allow_nil: false,
       allow_blank: false,
       strict: true,
-      message: "message"
+      message: "message",
+      full_message_format: false,
+      full_message: "message",
     )
 
     assert_equal(

--- a/activemodel/test/cases/errors_test.rb
+++ b/activemodel/test/cases/errors_test.rb
@@ -596,6 +596,12 @@ class ErrorsTest < ActiveModel::TestCase
     assert_equal "press the button", person.errors.full_message(:base, "press the button")
   end
 
+  test "full_message returns the given message when full_message_format is passed in" do
+    person = Person.new
+    assert_equal "cannot be blank", person.errors.full_message(:name, "cannot be blank", full_message_format: "%{message}")
+    assert_equal "cannot be blank", person.errors.full_message(:name_test, "cannot be blank", full_message_format: "%{message}")
+  end
+
   test "full_message returns the given message with the attribute name included" do
     person = Person.new
     assert_equal "name cannot be blank", person.errors.full_message(:name, "cannot be blank")


### PR DESCRIPTION
### Summary

Currently, the default format for a full error message is `'%{attribute} %{message}'` this can only be changed with the help of locales and i18n for both ActiveModels & ActiveRecords. This new feature adds the ability to format a full error message of an attribute without locales files. It can now be used on any classes that include `ActiveModel::Validations` and fully formatted error messages can be displayed consistently on web views as:

* a group with `errors.full_messages` (on top of a form like the scaffold generator for example)
* next to their appropriate form field with `errors.where(:attribute_name)`. 

This allows more flexibility on the error message displayed to the user while keeping the default validators (presence, uniqueness, inclusion...).

Additionally, It seems that the format required from people is either `'%{attribute} %{message}'` or `'%{message}'` this patch  adds a `full_message` option which is a shortcut that uses the `full_message_format: '%{message}'` option introduced.

At the end of the description, I provide a code sample for anyone to test it on their laptop. 

### Usage

For apps using locales and i18n nothing has changed. For apps that don't rely much on i18n, devs can format full error messages in the model definition.

Here is a description of the new suggested behaviour, existing behaviour still applies.

```ruby
class Person
  include ActiveModel::Model

  attr_accessor :age, :name

  validates :age, numericality: {
                                  greater_than_or_equal_to: 18,
                                  message: 'A person must be over 18',
                                  full_message_format: '%{message}'
                                }

  validates :name, presence: { full_message: 'A person name cannot be blank' }
end

Person.new(age: 17).tap(&:valid?).errors.full_messages
# => ["A person must be over 18", "A person name cannot be blank"]
```

### Why?

I work with clients that want validation steps or custom error messages that don't necessarily start with the attribute name. Sometimes I wish I had the flexibility of `:base` errors for an attribute without having to write down custom validation methods and keep a consistent way to display error messages on the view.

### Other

Haven't benchmarked it.

As I'm writing the description, I realise people have tried to do this for a while now:

* https://github.com/rails/rails/pull/12457#issuecomment-70334857
* https://github.com/rails/rails/pull/32919

And we can override the format with I18n:
* https://github.com/rails/rails/pull/32956


### Test

You can copy-paste this gist to test it locally.

```ruby
# frozen_string_literal: true

require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  git_source(:github) { |repo| "https://github.com/#{repo}.git" }

  gem "rails", github: "alexb52/rails", branch: "full_message_updates"
  gem "byebug"
end

require "active_model"
require "minitest/autorun"
require "logger"
require "byebug"

class Person
  include ActiveModel::Validations

  attr_accessor :name, :favourite_colour, :legacy_code

  validates :name, presence: true # default
  validates :favourite_colour, inclusion: { in: ["blue", "red"], message: "A person favourite colour must be blue or red", full_message_format: '%{message}' }
  validates :legacy_code, format: { with: /\A[a-zA-Z]+\z/, full_message: "PDLP must only include letters" }
end

class PersonTest < Minitest::Test
  def setup
    @errors = Person.new.tap(&:valid?).errors
  end

  def test_full_messages
    assert_equal @errors.full_messages, [
      "Name can't be blank",
      "A person favourite colour must be blue or red",
      "PDLP must only include letters"
    ]
  end

  def test_full_messages_for
    assert_equal @errors.full_messages_for(:name),             ["Name can't be blank"]
    assert_equal @errors.full_messages_for(:favourite_colour), ["A person favourite colour must be blue or red"]
    assert_equal @errors.full_messages_for(:legacy_code),      ["PDLP must only include letters"]
  end

  def test_message
    assert_equal @errors.where(:name).map(&:message),             ["can't be blank"]
    assert_equal @errors.where(:favourite_colour).map(&:message), ["A person favourite colour must be blue or red"]
    assert_equal @errors.where(:legacy_code).map(&:message),      ["PDLP must only include letters"]
  end
end
```
